### PR TITLE
Fix flaky test PrinterTest#testPrettyPrinting

### DIFF
--- a/src/test/java/us/bpsm/edn/printer/PrinterTest.java
+++ b/src/test/java/us/bpsm/edn/printer/PrinterTest.java
@@ -109,10 +109,10 @@ public class PrinterTest {
 
     @Test
     public void testPrettyPrinting() {
-        Map<Integer, String> m = new HashMap();
+        Map<Integer, String> m = new LinkedHashMap();
         m.put(3, "Three");
         m.put(4, "Four");
-        List<?> list = Arrays.asList(new HashSet(Arrays.asList(1, 2)), m);
+        List<?> list = Arrays.asList(new LinkedHashSet(Arrays.asList(1, 2)), m);
         String s = Printers.printString(Printers.prettyPrinterProtocol(), list);
         assertEquals("[\n  #{\n    1\n    2\n  }\n  {\n    3 \"Three\"\n    4 \"Four\"\n  }\n]", s);
     }


### PR DESCRIPTION
The test `PrinterTest#testPrettyPrinting` compares the result of `Printers.printString` to a hard-coded string based on a specific order of entries in `HashMap` and `HashSet`. However, these classes do not guarantee that order, and the assertion can fail if the order differs.

The PR uses `LinkedHashMap` and `LinkedHashSet` to make the order and the string deterministic.